### PR TITLE
Add check whether there is data on extraction of read_file_definitions

### DIFF
--- a/ulog_parser/__init__.py
+++ b/ulog_parser/__init__.py
@@ -280,6 +280,8 @@ class ULog:
     def read_file_definitions(self):
         while(True):
             data = self.file_handle.read(3)
+            if not data:
+                break;
             header = self.MessageHeader(data)
             data = self.file_handle.read(header.msg_size)
             if (header.msg_type == self.MSG_TYPE_INFO):


### PR DESCRIPTION
checks whether there is still data while looking for definitions
this is necessary if there are no logged messages but only the ulog "Header",
info.py fails otherwise.