### PR TITLE
Fixed ulog2kml by adding line to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'ulog_messages=pyulog.messages:main',
             'ulog_params=pyulog.params:main',
             'ulog2csv=pyulog.ulog2csv:main',
+            'ulog2kml=pyulog.ulog2kml:main',
         ],
     },
     packages=find_packages(),


### PR DESCRIPTION
This is a fix for #21. The line to fix it is this : 'ulog2kml=pyulog.ulog2kml:main' and it's added to setup.py.