### PR TITLE
params: output changed parameter timestamps in csv

### DIFF
--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -25,7 +25,7 @@ def main():
 
     parser.add_argument('-o', '--octave', dest='octave', action='store_true',
                         help='Use Octave format', default=False)
-                        
+
     parser.add_argument('-t', '--timestamps', dest='timestamps', action='store_true',
                         help='Extract changed parameters with timestamps', default=False)
 
@@ -75,7 +75,7 @@ def main():
                     if name == param_key:
                         output_file.write(delimiter)
                         output_file.write(str(value))
-										
+
                 output_file.write('\n')
 
     else:

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -25,6 +25,9 @@ def main():
 
     parser.add_argument('-o', '--octave', dest='octave', action='store_true',
                         help='Use Octave format', default=False)
+                        
+    parser.add_argument('-t', '--timestamps', dest='timestamps', action='store_true',
+                        help='Extract changed parameters with timestamps', default=False)
 
     parser.add_argument('output_filename', metavar='params.txt',
                         type=argparse.FileType('w'), nargs='?',
@@ -49,7 +52,7 @@ def main():
                 output_file.write(delimiter)
                 output_file.write(str(ulog.initial_parameters[param_key]))
                 output_file.write('\n')
-            else:
+            elif args.timestamps:
                 output_file.write(delimiter)
                 output_file.write(str(ulog.initial_parameters[param_key]))
                 for t, name, value in ulog.changed_parameters:
@@ -66,6 +69,13 @@ def main():
                         output_file.write(delimiter)
                         output_file.write(str(t))
 
+                output_file.write('\n')
+            else:
+                for t, name, value in ulog.changed_parameters:
+                    if name == param_key:
+                        output_file.write(delimiter)
+                        output_file.write(str(value))
+										
                 output_file.write('\n')
 
     else:

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -45,14 +45,28 @@ def main():
     if not args.octave:
         for param_key in param_keys:
             output_file.write(param_key)
-            output_file.write(delimiter)
-            output_file.write(str(ulog.initial_parameters[param_key]))
-            if not args.initial:
+            if args.initial:
+                output_file.write(delimiter)
+                output_file.write(str(ulog.initial_parameters[param_key]))
+                output_file.write('\n')
+            else:
+                output_file.write(delimiter)
+                output_file.write(str(ulog.initial_parameters[param_key]))
                 for t, name, value in ulog.changed_parameters:
                     if name == param_key:
                         output_file.write(delimiter)
                         output_file.write(str(value))
-            output_file.write('\n')
+
+                output_file.write('\n')
+                output_file.write("timestamp")
+                output_file.write(delimiter)
+                output_file.write('0')
+                for t, name, value in ulog.changed_parameters:
+                    if name == param_key:
+                        output_file.write(delimiter)
+                        output_file.write(str(t))
+
+                output_file.write('\n')
 
     else:
 


### PR DESCRIPTION
Outputs changed parameters and their timestamps in csv. This is just one way to format this -- open to other ideas. "0" is used as the timestamp for the initial parameter.

resolves #26 

Output in the csv formatted like this:

| column 1      | column 2      | column 3      | column 4      |
| ------------- | ------------- | ------------- | ------------- |
| PARAM 1       | init val      | changed val 1 | changed val 2 |
| timestamp     | 0             | timestamp 1   | timestamp 2   |
| PARAM 2       | init val      | changed val 1 | changed val 2 |
| timestamp     | 0             | timestamp 1   | timestamp 2   |

Ex. sample output from a ulog:

| column 1         | column 2         | column 3         | column 4         |
| ---------------- | ---------------- | ---------------- | ---------------- |
| FW_RLL_TO_YAW_FF | 0                |                  |                  |
| timestamp        | 0                |                  |                  |
| FW_RR_FF         | 0.8999999762     | 1.2000000477     | 1                |
| timestamp        | 0                | 429617575        | 791731803        |
| FW_RR_I          | 0.1000000015     |                  |                  |
| timestamp        | 0                |                  |                  |





