### PR TITLE
More robustness to corrupt messages: rewind file pointer when reading messages with unknown type

### DIFF
--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -526,6 +526,7 @@ class ULog(object):
             while True:
                 data = self._file_handle.read(3)
                 header.initialize(data)
+                last_file_position = self._file_handle.tell()
                 data = self._file_handle.read(header.msg_size)
                 if len(data) < header.msg_size:
                     break # less data than expected. File is most likely cut
@@ -566,6 +567,7 @@ class ULog(object):
                                                       self._last_timestamp)
                     self._dropouts.append(msg_dropout)
                 else:
+                    self._file_handle.seek(last_file_position)
                     if self._debug:
                         print('_read_file_data: unknown message type: %i (%s)' %
                               (header.msg_type, chr(header.msg_type)))


### PR DESCRIPTION
The main problem is when reading a message with an unknown type. Even before we test the type, the "read(header.msg_size)" is done, so we advance the file pointer header.msg_size bytes. When this type is unknown and can be corrupt, this number can be randomly large, prevent the read of possible good messages that come after. Rewinding the file pointer to right after the corrupt header helps recovering at least some possible good messages that come after the corruption.

I tested this and was able to recuperate an important part of a corrupted log file.