### PR TITLE
Parametrize string parsing error handling

### DIFF
--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -14,8 +14,8 @@ __author__ = "Beat Kueng"
 # check python version
 if sys.hexversion >= 0x030000F0:
     _RUNNING_PYTHON3 = True
-    def _parse_string(cstr):
-        return str(cstr, 'ascii')
+    def _parse_string(cstr, errors='strict'):
+        return str(cstr, 'utf-8', errors)
 else:
     _RUNNING_PYTHON3 = False
     def _parse_string(cstr):
@@ -73,14 +73,28 @@ class ULog(object):
     _unpack_ushort = struct.Struct('<H').unpack
     _unpack_uint64 = struct.Struct('<Q').unpack
 
+    # when set to True disables string parsing exceptions
+    _disable_str_exceptions = False
 
-    def __init__(self, log_file, message_name_filter_list=None):
+    @staticmethod
+    def parse_string(cstr):
+        """
+        wrapper for _parse_string with
+        parametrized exception handling
+        """
+        if _RUNNING_PYTHON3 and ULog._disable_str_exceptions:
+            return _parse_string(cstr, 'ignore')
+        else:
+            return _parse_string(cstr)
+
+    def __init__(self, log_file, message_name_filter_list=None, disable_str_exceptions=True):
         """
         Initialize the object & load the file.
 
         :param log_file: a file name (str) or a readable file object
         :param message_name_filter_list: list of strings, to only load messages
                with the given names. If None, load everything.
+        :param disable_str_parser_exceptions: If True, ignore string parsing errors
         """
 
         self._debug = False
@@ -105,6 +119,7 @@ class ULog(object):
         self._compat_flags = [0] * 8
         self._incompat_flags = [0] * 8
         self._appended_offsets = [] # file offsets for appended data
+        ULog._disable_str_exceptions = disable_str_exceptions
 
         self._load_file(log_file, message_name_filter_list)
 
@@ -247,12 +262,12 @@ class ULog(object):
                 self.is_continued, = struct.unpack('<B', data[0:1])
                 data = data[1:]
             key_len, = struct.unpack('<B', data[0:1])
-            type_key = _parse_string(data[1:1+key_len])
+            type_key = ULog.parse_string(data[1:1+key_len])
             type_key_split = type_key.split(' ')
             self.type = type_key_split[0]
             self.key = type_key_split[1]
             if self.type.startswith('char['): # it's a string
-                self.value = _parse_string(data[1+key_len:])
+                self.value = ULog.parse_string(data[1+key_len:])
             elif self.type in ULog._UNPACK_TYPES:
                 unpack_type = ULog._UNPACK_TYPES[self.type]
                 self.value, = struct.unpack('<'+unpack_type[0], data[1+key_len:])
@@ -279,7 +294,7 @@ class ULog(object):
         """ ULog message format representation """
 
         def __init__(self, data, header):
-            format_arr = _parse_string(data).split(':')
+            format_arr = ULog.parse_string(data).split(':')
             self.name = format_arr[0]
             types_str = format_arr[1].split(';')
             self.fields = [] # list of tuples (type, array_size, name)
@@ -308,7 +323,7 @@ class ULog(object):
         def __init__(self, data, header):
             self.log_level, = struct.unpack('<B', data[0:1])
             self.timestamp, = struct.unpack('<Q', data[1:9])
-            self.message = _parse_string(data[9:])
+            self.message = ULog.parse_string(data[9:])
 
         def log_level_str(self):
             return {ord('0'): 'EMERGENCY',
@@ -337,7 +352,7 @@ class ULog(object):
         def __init__(self, data, header, message_formats):
             self.multi_id, = struct.unpack('<B', data[0:1])
             self.msg_id, = struct.unpack('<H', data[1:3])
-            self.message_name = _parse_string(data[3:])
+            self.message_name = ULog.parse_string(data[3:])
             self.field_data = [] # list of _FieldData
             self.timestamp_idx = -1
             self._parse_format(message_formats)

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -82,10 +82,12 @@ class ULog(object):
         wrapper for _parse_string with
         parametrized exception handling
         """
+        ret = ''
         if _RUNNING_PYTHON3 and ULog._disable_str_exceptions:
-            return _parse_string(cstr, 'ignore')
+            ret = _parse_string(cstr, 'ignore')
         else:
-            return _parse_string(cstr)
+            ret = _parse_string(cstr)
+        return ret
 
     def __init__(self, log_file, message_name_filter_list=None, disable_str_exceptions=True):
         """

--- a/pyulog/extract_gps_dump.py
+++ b/pyulog/extract_gps_dump.py
@@ -29,12 +29,15 @@ def main():
     parser.add_argument('-o', '--output', dest='output', action='store',
                         help='Output directory (default is CWD)',
                         metavar='DIR', type=lambda x: is_valid_directory(parser, x))
+    parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
 
     args = parser.parse_args()
     ulog_file_name = args.filename
+    disable_str_exceptions = args.ignore
 
     msg_filter = ['gps_dump']
-    ulog = ULog(ulog_file_name, msg_filter)
+    ulog = ULog(ulog_file_name, msg_filter, disable_str_exceptions)
     data = ulog.data_list
 
     output_file_prefix = os.path.basename(ulog_file_name)

--- a/pyulog/info.py
+++ b/pyulog/info.py
@@ -75,11 +75,14 @@ def main():
                         help='Show a specific Info Multiple Message')
     parser.add_argument('-n', '--newline', dest='newline', action='store_true',
                         help='Add newline separators (only with --message)', default=False)
+    parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
 
 
     args = parser.parse_args()
     ulog_file_name = args.filename
-    ulog = ULog(ulog_file_name)
+    disable_str_exceptions = args.ignore
+    ulog = ULog(ulog_file_name, None, disable_str_exceptions)
     message = args.message
     if message:
         separator = ""

--- a/pyulog/messages.py
+++ b/pyulog/messages.py
@@ -15,13 +15,15 @@ def main():
 
     parser = argparse.ArgumentParser(description='Display logged messages from an ULog file')
     parser.add_argument('filename', metavar='file.ulg', help='ULog input file')
-
+    parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
 
     args = parser.parse_args()
     ulog_file_name = args.filename
+    disable_str_exceptions = args.ignore
 
     msg_filter = [] # we don't need the data messages
-    ulog = ULog(ulog_file_name, msg_filter)
+    ulog = ULog(ulog_file_name, msg_filter, disable_str_exceptions)
 
 
     for m in ulog.logged_messages:

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -33,13 +33,17 @@ def main():
                         type=argparse.FileType('w'), nargs='?',
                         help='Output filename (default=stdout)', default=sys.stdout)
 
+    parser.add_argument('-g', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
+
     args = parser.parse_args()
     ulog_file_name = args.filename
+    disable_str_exceptions = args.ignore
 
     message_filter = []
     if not args.initial: message_filter = None
 
-    ulog = ULog(ulog_file_name, message_filter)
+    ulog = ULog(ulog_file_name, message_filter, disable_str_exceptions)
 
     param_keys = sorted(ulog.initial_parameters.keys())
     delimiter = args.delimiter

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -33,7 +33,7 @@ def main():
                         type=argparse.FileType('w'), nargs='?',
                         help='Output filename (default=stdout)', default=sys.stdout)
 
-    parser.add_argument('-g', '--ignore', dest='ignore', action='store_true',
+    parser.add_argument('--ignore', dest='ignore', action='store_true',
                         help='Ignore string parsing exceptions', default=False)
 
     args = parser.parse_args()

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -42,7 +42,7 @@ def main():
     convert_ulog2csv(args.filename, args.messages, args.output, args.delimiter, args.ignore)
 
 
-def convert_ulog2csv(ulog_file_name, messages, output, delimiter, disable_str_exceptions):
+def convert_ulog2csv(ulog_file_name, messages, output, delimiter, disable_str_exceptions=False):
     """
     Coverts and ULog file to a CSV file.
 

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -30,6 +30,8 @@ def main():
     parser.add_argument('-o', '--output', dest='output', action='store',
                         help='Output directory (default is same as input file)',
                         metavar='DIR')
+    parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
 
     args = parser.parse_args()
 
@@ -37,10 +39,10 @@ def main():
         print('Creating output directory {:}'.format(args.output))
         os.mkdir(args.output)
 
-    convert_ulog2csv(args.filename, args.messages, args.output, args.delimiter)
+    convert_ulog2csv(args.filename, args.messages, args.output, args.delimiter, args.ignore)
 
 
-def convert_ulog2csv(ulog_file_name, messages, output, delimiter):
+def convert_ulog2csv(ulog_file_name, messages, output, delimiter, disable_str_exceptions):
     """
     Coverts and ULog file to a CSV file.
 
@@ -54,7 +56,7 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter):
 
     msg_filter = messages.split(',') if messages else None
 
-    ulog = ULog(ulog_file_name, msg_filter)
+    ulog = ULog(ulog_file_name, msg_filter, disable_str_exceptions)
     data = ulog.data_list
 
     output_file_prefix = ulog_file_name

--- a/pyulog/ulog2kml.py
+++ b/pyulog/ulog2kml.py
@@ -29,12 +29,15 @@ def main():
     parser.add_argument('--camera-trigger', dest='camera_trigger',
                         help="Camera trigger topic name (e.g. camera_capture)",
                         default=None)
+    parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
 
     args = parser.parse_args()
 
     convert_ulog2kml(args.filename, args.output_filename,
                      position_topic_name=args.topic_name,
-                     camera_trigger_topic_name=args.camera_trigger)
+                     camera_trigger_topic_name=args.camera_trigger,
+                     disable_str_exceptions=args.ignore)
 
     # alternative example call:
 #    convert_ulog2kml(args.filename, 'test.kml', ['vehicle_global_position',
@@ -54,7 +57,8 @@ def _kml_default_colors(x):
 
 def convert_ulog2kml(ulog_file_name, output_file_name, position_topic_name=
                      'vehicle_gps_position', colors=_kml_default_colors, altitude_offset=0,
-                     minimum_interval_s=0.1, style=None, camera_trigger_topic_name=None):
+                     minimum_interval_s=0.1, style=None, camera_trigger_topic_name=None,
+                     disable_str_exceptions=False):
     """
     Coverts and ULog file to a CSV file.
 
@@ -96,7 +100,7 @@ def convert_ulog2kml(ulog_file_name, output_file_name, position_topic_name=
     load_topic_names = position_topic_name + ['vehicle_status']
     if camera_trigger_topic_name is not None:
         load_topic_names.append(camera_trigger_topic_name)
-    ulog = ULog(ulog_file_name, load_topic_names)
+    ulog = ULog(ulog_file_name, load_topic_names, disable_str_exceptions)
 
     # get flight modes
     try:


### PR DESCRIPTION
Fixes #38 

@bkueng I do not much like setting the static variable in the __init__ fn, but the alternative I see is passing parameters everywhere till they reach _parse_string() which is ugly as well.