### PR TITLE
Speedup by replacing .tell() calls

### DIFF
--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -591,7 +591,7 @@ class ULog(object):
         while len(chunk) > 0:
             current_file_position += len(chunk)
             chunk_index = chunk.find(ULog.SYNC_BYTES)
-            if chunk_index > 0:
+            if chunk_index >= 0:
                 if self._debug:
                     print("Found sync at %i" % current_file_position - len(chunk) + chunk_index)
                 # seek to end of sync sequence and break

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -587,25 +587,26 @@ class ULog(object):
             current_file_position = self._file_handle.seek(-last_n_bytes, 1)
             search_chunk_size = last_n_bytes
 
-        s = self._file_handle.read(search_chunk_size)
-        while len(s) > 0:
-            current_file_position += len(s)
-
-            k = s.find(ULog.SYNC_BYTES)
-            if k > 0:
-                print("Found sync sequence at [%i, %i]" %\
-                            (current_file_position - len(s) + k, current_file_position - len(s) + k + len(ULog.SYNC_BYTES)))
+        chunk = self._file_handle.read(search_chunk_size)
+        while len(chunk) > 0:
+            current_file_position += len(chunk)
+            chunk_index = chunk.find(ULog.SYNC_BYTES)
+            if chunk_index > 0:
+                if self._debug:
+                    print("Found sync at %i" % current_file_position - len(chunk) + chunk_index)
                 # seek to end of sync sequence and break
-                current_file_position = self._file_handle.seek(current_file_position - len(s) + k + len(ULog.SYNC_BYTES), 0)
+                current_file_position = self._file_handle.seek(current_file_position - len(chunk)\
+                         + chunk_index + len(ULog.SYNC_BYTES), 0)
                 sync_seq_found = True
                 break
 
             elif last_n_bytes != -1:
+                # we read the whole last_n_bytes and did not find sync
                 break
 
             else:
                 # read next chunk
-                s = self._file_handle.read(search_chunk_size)
+                chunk = self._file_handle.read(search_chunk_size)
 
         if not sync_seq_found:
             current_file_position = self._file_handle.seek(initial_file_position, 0)

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -604,9 +604,9 @@ class ULog(object):
                 # we read the whole last_n_bytes and did not find sync
                 break
 
-            else:
-                # read next chunk
-                chunk = self._file_handle.read(search_chunk_size)
+            # seek back 7 bytes to handle boundary condition and read next chunk
+            current_file_position = self._file_handle.seek(-7, 1)
+            chunk = self._file_handle.read(search_chunk_size)
 
         if not sync_seq_found:
             current_file_position = self._file_handle.seek(initial_file_position, 0)

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -582,17 +582,16 @@ class ULog(object):
         current_file_position = initial_file_position
 
         if last_n_bytes != -1:
-            self._file_handle.seek(-last_n_bytes, 1)
-            current_file_position = current_file_position - last_n_bytes
+            current_file_position = self._file_handle.seek(-last_n_bytes, 1)
 
         sync_start = self._file_handle.read(1)
-        current_file_position = current_file_position + 1
+        current_file_position += 1
         try:
             while last_n_bytes == -1 or\
              (current_file_position < initial_file_position):
                 if sync_start[0] == ULog.SYNC_BYTES[0]:
                     data = self._file_handle.read(7)
-                    current_file_position = current_file_position + 7
+                    current_file_position += len(data)
                     if data == ULog.SYNC_BYTES[1:]:
                         sync_seq_found = True
                         if self._debug:
@@ -602,18 +601,16 @@ class ULog(object):
 
                     else:
                         # seek back 7 bytes and look for sync start again
-                        self._file_handle.seek(-7, 1)
-                        current_file_position = current_file_position - 7
+                        current_file_position = self._file_handle.seek(-7, 1)
                 sync_start = self._file_handle.read(1)
-                current_file_position = current_file_position + 1
+                current_file_position += 1
         except IndexError:
             # Reached end of file
             if self._debug:
                 print("_find_sync(): reached EOF")
 
         if not sync_seq_found:
-            self._file_handle.seek(initial_file_position, 0)
-            current_file_position = initial_file_position
+            current_file_position = self._file_handle.seek(initial_file_position, 0)
 
             if last_n_bytes == -1:
                 self._has_sync = False

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -581,7 +581,7 @@ class ULog(object):
         initial_file_position = self._file_handle.tell()
         current_file_position = initial_file_position
 
-        search_chunk_size = 512 # number of bytes that are searched at ones
+        search_chunk_size = 512 # number of bytes that are searched at once
 
         if last_n_bytes != -1:
             current_file_position = self._file_handle.seek(-last_n_bytes, 1)

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -588,12 +588,12 @@ class ULog(object):
             search_chunk_size = last_n_bytes
 
         chunk = self._file_handle.read(search_chunk_size)
-        while len(chunk) > 0:
+        while len(chunk) >= len(ULog.SYNC_BYTES):
             current_file_position += len(chunk)
             chunk_index = chunk.find(ULog.SYNC_BYTES)
             if chunk_index >= 0:
                 if self._debug:
-                    print("Found sync at %i" % current_file_position - len(chunk) + chunk_index)
+                    print("Found sync at %i" % (current_file_position - len(chunk) + chunk_index))
                 # seek to end of sync sequence and break
                 current_file_position = self._file_handle.seek(current_file_position - len(chunk)\
                          + chunk_index + len(ULog.SYNC_BYTES), 0)

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -581,33 +581,31 @@ class ULog(object):
         initial_file_position = self._file_handle.tell()
         current_file_position = initial_file_position
 
+        search_chunk_size = 512 # number of bytes that are searched at ones
+
         if last_n_bytes != -1:
             current_file_position = self._file_handle.seek(-last_n_bytes, 1)
+            search_chunk_size = last_n_bytes
 
-        sync_start = self._file_handle.read(1)
-        current_file_position += 1
-        try:
-            while last_n_bytes == -1 or\
-             (current_file_position < initial_file_position):
-                if sync_start[0] == ULog.SYNC_BYTES[0]:
-                    data = self._file_handle.read(7)
-                    current_file_position += len(data)
-                    if data == ULog.SYNC_BYTES[1:]:
-                        sync_seq_found = True
-                        if self._debug:
-                            print("Found sync sequence at [%i, %i]" %\
-                                (self._file_handle.tell() - 8, self._file_handle.tell()))
-                        break
+        s = self._file_handle.read(search_chunk_size)
+        while len(s) > 0:
+            current_file_position += len(s)
 
-                    else:
-                        # seek back 7 bytes and look for sync start again
-                        current_file_position = self._file_handle.seek(-7, 1)
-                sync_start = self._file_handle.read(1)
-                current_file_position += 1
-        except IndexError:
-            # Reached end of file
-            if self._debug:
-                print("_find_sync(): reached EOF")
+            k = s.find(ULog.SYNC_BYTES)
+            if k > 0:
+                print("Found sync sequence at [%i, %i]" %\
+                            (current_file_position - len(s) + k, current_file_position - len(s) + k + len(ULog.SYNC_BYTES)))
+                # seek to end of sync sequence and break
+                current_file_position = self._file_handle.seek(current_file_position - len(s) + k + len(ULog.SYNC_BYTES), 0)
+                sync_seq_found = True
+                break
+
+            elif last_n_bytes != -1:
+                break
+
+            else:
+                # read next chunk
+                s = self._file_handle.read(search_chunk_size)
 
         if not sync_seq_found:
             current_file_position = self._file_handle.seek(initial_file_position, 0)


### PR DESCRIPTION
Speedup parsing by eliminating repeated calls to file_handle.tell().

Before:

```
In [12]: cProfile.run("ULog('/home/bharat/Downloads/final_obc2_bad2.ulg')")
         8063278 function calls (8063275 primitive calls) in 3.670 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1694    0.001    0.000    0.001    0.000 <ipython-input-10-ae14ac574a72>:17(_parse_string)
        1    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:195(has_data_appended)
       33    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:226(__init__)
        2    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:263(__init__)
   547023    0.134    0.000    0.175    0.000 <ipython-input-10-ae14ac574a72>:267(initialize)
      814    0.002    0.000    0.003    0.000 <ipython-input-10-ae14ac574a72>:273(__init__)
        1    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:293(__init__)
      128    0.001    0.000    0.003    0.000 <ipython-input-10-ae14ac574a72>:309(__init__)
     1341    0.001    0.000    0.001    0.000 <ipython-input-10-ae14ac574a72>:318(_extract_type)
      612    0.001    0.000    0.003    0.000 <ipython-input-10-ae14ac574a72>:336(__init__)
      810    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:378(__init__)
       33    0.001    0.000    0.002    0.000 <ipython-input-10-ae14ac574a72>:384(__init__)
       33    0.000    0.000    0.001    0.000 <ipython-input-10-ae14ac574a72>:408(_parse_format)
    36/33    0.001    0.000    0.001    0.000 <ipython-input-10-ae14ac574a72>:416(_parse_nested_type)
        1    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:440(__init__)
   518833    0.418    0.000    0.511    0.000 <ipython-input-10-ae14ac574a72>:443(initialize)
       96    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:463(_add_message_info_multiple)
        1    0.000    0.000    3.668    3.668 <ipython-input-10-ae14ac574a72>:473(_load_file)
        1    0.000    0.000    0.000    0.000 <ipython-input-10-ae14ac574a72>:498(_read_file_header)
        1    0.002    0.002    0.009    0.009 <ipython-input-10-ae14ac574a72>:511(_read_file_definitions)
    23348    0.535    0.000    1.601    0.000 <ipython-input-10-ae14ac574a72>:570(_find_sync)
        1    0.816    0.816    3.660    3.660 <ipython-input-10-ae14ac574a72>:622(_read_file_data)
    23348    0.006    0.000    0.006    0.000 <ipython-input-10-ae14ac574a72>:711(_check_packet_corruption)
     1694    0.001    0.000    0.002    0.000 <ipython-input-10-ae14ac574a72>:81(parse_string)
        1    0.000    0.000    3.669    3.669 <ipython-input-10-ae14ac574a72>:94(__init__)
        1    0.002    0.002    3.670    3.670 <string>:1(<module>)
        1    0.000    0.000    0.000    0.000 vt100_input.py:278(_input_parser_generator)
     2911    0.001    0.000    0.001    0.000 {built-in method _struct.unpack}
        1    0.000    0.000    3.670    3.670 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
   547827    0.036    0.000    0.036    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {built-in method io.open}
       33    0.000    0.000    0.000    0.000 {built-in method numpy.core.multiarray.frombuffer}
     3598    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 {method 'close' of '_io.BufferedReader' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     1543    0.000    0.000    0.000    0.000 {method 'find' of 'str' objects}
       33    0.000    0.000    0.000    0.000 {method 'newbyteorder' of 'numpy.dtype' objects}
      103    0.000    0.000    0.000    0.000 {method 'pop' of 'list' objects}
       33    0.000    0.000    0.000    0.000 {method 'popitem' of 'dict' objects}
  2644694    0.301    0.000    0.301    0.000 {method 'read' of '_io.BufferedReader' objects}
    47993    0.011    0.000    0.011    0.000 {method 'seek' of '_io.BufferedReader' objects}
     2411    0.001    0.000    0.001    0.000 {method 'split' of 'str' objects}
      947    0.000    0.000    0.000    0.000 {method 'startswith' of 'str' objects}
  2106569    1.262    0.000    1.262    0.000 {method 'tell' of '_io.BufferedReader' objects}
  1584690    0.135    0.000    0.135    0.000 {method 'unpack' of 'Struct' objects}

```


After

```
cProfile.run("ULog('/home/bharat/Downloads/final_obc2_bad2.ulg')")
6526212 function calls (6526209 primitive calls) in 2.662 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1694    0.002    0.000    0.002    0.000 <ipython-input-13-d5d38212270c>:17(_parse_string)
        1    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:195(has_data_appended)
       33    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:226(__init__)
        2    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:263(__init__)
   547023    0.129    0.000    0.170    0.000 <ipython-input-13-d5d38212270c>:267(initialize)
      814    0.006    0.000    0.012    0.000 <ipython-input-13-d5d38212270c>:273(__init__)
        1    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:293(__init__)
      128    0.003    0.000    0.010    0.000 <ipython-input-13-d5d38212270c>:309(__init__)
     1341    0.003    0.000    0.005    0.000 <ipython-input-13-d5d38212270c>:318(_extract_type)
      612    0.001    0.000    0.003    0.000 <ipython-input-13-d5d38212270c>:336(__init__)
      810    0.002    0.000    0.002    0.000 <ipython-input-13-d5d38212270c>:378(__init__)
       33    0.001    0.000    0.005    0.000 <ipython-input-13-d5d38212270c>:384(__init__)
       33    0.000    0.000    0.003    0.000 <ipython-input-13-d5d38212270c>:408(_parse_format)
    36/33    0.001    0.000    0.003    0.000 <ipython-input-13-d5d38212270c>:416(_parse_nested_type)
        1    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:440(__init__)
   518833    0.408    0.000    0.500    0.000 <ipython-input-13-d5d38212270c>:443(initialize)
       96    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:463(_add_message_info_multiple)
        1    0.000    0.000    2.661    2.661 <ipython-input-13-d5d38212270c>:473(_load_file)
        1    0.000    0.000    0.000    0.000 <ipython-input-13-d5d38212270c>:498(_read_file_header)
        1    0.007    0.007    0.033    0.033 <ipython-input-13-d5d38212270c>:511(_read_file_definitions)
    23348    0.382    0.000    0.549    0.000 <ipython-input-13-d5d38212270c>:570(_find_sync)
        1    0.851    0.851    2.628    2.628 <ipython-input-13-d5d38212270c>:629(_read_file_data)
    23348    0.006    0.000    0.006    0.000 <ipython-input-13-d5d38212270c>:718(_check_packet_corruption)
     1694    0.002    0.000    0.004    0.000 <ipython-input-13-d5d38212270c>:81(parse_string)
        1    0.000    0.000    2.661    2.661 <ipython-input-13-d5d38212270c>:94(__init__)
        1    0.002    0.002    2.662    2.662 <string>:1(<module>)
        1    0.000    0.000    0.000    0.000 vt100_input.py:278(_input_parser_generator)
     2911    0.002    0.000    0.002    0.000 {built-in method _struct.unpack}
        1    0.000    0.000    2.662    2.662 {built-in method builtins.exec}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
   547827    0.036    0.000    0.036    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {built-in method io.open}
       33    0.000    0.000    0.000    0.000 {built-in method numpy.core.multiarray.frombuffer}
     3598    0.001    0.000    0.001    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 {method 'close' of '_io.BufferedReader' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
     1543    0.001    0.000    0.001    0.000 {method 'find' of 'str' objects}
       33    0.000    0.000    0.000    0.000 {method 'newbyteorder' of 'numpy.dtype' objects}
      103    0.000    0.000    0.000    0.000 {method 'pop' of 'list' objects}
       33    0.000    0.000    0.000    0.000 {method 'popitem' of 'dict' objects}
  2644694    0.294    0.000    0.294    0.000 {method 'read' of '_io.BufferedReader' objects}
    47993    0.012    0.000    0.012    0.000 {method 'seek' of '_io.BufferedReader' objects}
     2411    0.003    0.000    0.003    0.000 {method 'split' of 'str' objects}
      947    0.001    0.000    0.001    0.000 {method 'startswith' of 'str' objects}
   569503    0.372    0.000    0.372    0.000 {method 'tell' of '_io.BufferedReader' objects}
  1584690    0.133    0.000    0.133    0.000 {method 'unpack' of 'Struct' objects}

```

Note that so many calls to find sync only happen when you do have unknown message type in your ULog file.