### PR TITLE
QGC compatible formatting for `ulog_params`

### DIFF
--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -90,7 +90,7 @@ def main():
                 output_file.write(str(param_value))
                 output_file.write(delimiter)
 
-                if str(param_value).find('.') != -1:
+                if isinstance(param_value, float):
                     # Float
                     param_type = 9
                 else:

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -29,6 +29,9 @@ def main():
     parser.add_argument('-t', '--timestamps', dest='timestamps', action='store_true',
                         help='Extract changed parameters with timestamps', default=False)
 
+    parser.add_argument('-q', '--qgc_compatibility', dest='qgc_compatibility', action='store_true',
+                        help='Extract parameters in QGC compatible format', default=False)
+
     parser.add_argument('output_filename', metavar='params.txt',
                         type=argparse.FileType('w'), nargs='?',
                         help='Output filename (default=stdout)', default=sys.stdout)
@@ -51,8 +54,8 @@ def main():
 
     if not args.octave:
         for param_key in param_keys:
-            output_file.write(param_key)
             if args.timestamps:
+                output_file.write(param_key)
                 output_file.write(delimiter)
                 output_file.write(str(ulog.initial_parameters[param_key]))
                 for t, name, value in ulog.changed_parameters:
@@ -70,7 +73,35 @@ def main():
                         output_file.write(str(t))
 
                 output_file.write('\n')
+
+            # QGC formatted parameter file
+            elif args.qgc_compatibility:
+                sys_id = 1
+                comp_id = 1
+                delimiter = '\t'
+                param_value = ulog.initial_parameters[param_key]
+
+                output_file.write(str(sys_id))
+                output_file.write(delimiter)
+                output_file.write(str(comp_id))
+                output_file.write(delimiter)
+                output_file.write(param_key)
+                output_file.write(delimiter)
+                output_file.write(str(param_value))
+                output_file.write(delimiter)
+
+                if str(param_value).find('.') != -1:
+                    # Float
+                    param_type = 9
+                else:
+                    # Int
+                    param_type = 6
+
+                output_file.write(str(param_type))
+                output_file.write('\n')
+
             else:
+                output_file.write(param_key)
                 output_file.write(delimiter)
                 output_file.write(str(ulog.initial_parameters[param_key]))
                 if not args.initial:

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -23,7 +23,7 @@ def main():
                         help='Extract changed parameters with timestamps. (csv)', default=False)
 
     parser.add_argument('-f', '--format', dest='format', action='store', type=str,
-                        help='csv|octave|qgc', default=False)
+                        help='csv|octave|qgc', default='csv')
 
     parser.add_argument('output_filename', metavar='params.txt',
                         type=argparse.FileType('w'), nargs='?',

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -17,10 +17,10 @@ def main():
     parser.add_argument('filename', metavar='file.ulg', help='ULog input file')
 
     parser.add_argument('-i', '--initial', dest='initial', action='store_true',
-                        help='Only extract initial parameters. (csv|octave|qgc)', default=False)
+                        help='Only extract initial parameters. (octave|csv)', default=False)
 
     parser.add_argument('-t', '--timestamps', dest='timestamps', action='store_true',
-                        help='Extract changed parameters with timestamps. (csv|qgc)', default=False)
+                        help='Extract changed parameters with timestamps. (csv)', default=False)
 
     parser.add_argument('-f', '--format', dest='format', action='store', type=str,
                         help='csv|octave|qgc', default=False)
@@ -45,10 +45,10 @@ def main():
     delimiter = ','
     output_file = args.output_filename
 
-    if not args.format == "octave":
+    if args.format == "csv":
         for param_key in param_keys:
+            output_file.write(param_key)
             if args.timestamps:
-                output_file.write(param_key)
                 output_file.write(delimiter)
                 output_file.write(str(ulog.initial_parameters[param_key]))
                 for t, name, value in ulog.changed_parameters:
@@ -66,34 +66,7 @@ def main():
                         output_file.write(str(t))
 
                 output_file.write('\n')
-
-            elif args.format == "qgc":
-                sys_id = 1
-                comp_id = 1
-                delimiter = '\t'
-                param_value = ulog.initial_parameters[param_key]
-
-                output_file.write(str(sys_id))
-                output_file.write(delimiter)
-                output_file.write(str(comp_id))
-                output_file.write(delimiter)
-                output_file.write(param_key)
-                output_file.write(delimiter)
-                output_file.write(str(param_value))
-                output_file.write(delimiter)
-
-                if isinstance(param_value, float):
-                    # Float
-                    param_type = 9
-                else:
-                    # Int
-                    param_type = 6
-
-                output_file.write(str(param_type))
-                output_file.write('\n')
-
             else:
-                output_file.write(param_key)
                 output_file.write(delimiter)
                 output_file.write(str(ulog.initial_parameters[param_key]))
                 if not args.initial:
@@ -103,7 +76,7 @@ def main():
                             output_file.write(str(value))
                 output_file.write('\n')
 
-    else:
+    elif args.format == "octave":
 
         for param_key in param_keys:
             output_file.write('# name ')
@@ -127,4 +100,31 @@ def main():
                 output_file.write('\n# type: scalar\n')
                 output_file.write(str(values[0]))
 
+            output_file.write('\n')
+
+    elif args.format == "qgc":
+
+        for param_key in param_keys:
+            sys_id = 1
+            comp_id = 1
+            delimiter = '\t'
+            param_value = ulog.initial_parameters[param_key]
+
+            output_file.write(str(sys_id))
+            output_file.write(delimiter)
+            output_file.write(str(comp_id))
+            output_file.write(delimiter)
+            output_file.write(param_key)
+            output_file.write(delimiter)
+            output_file.write(str(param_value))
+            output_file.write(delimiter)
+
+            if isinstance(param_value, float):
+                # Float
+                param_type = 9
+            else:
+                # Int
+                param_type = 6
+
+            output_file.write(str(param_type))
             output_file.write('\n')

--- a/pyulog/params.py
+++ b/pyulog/params.py
@@ -13,24 +13,17 @@ from .core import ULog
 
 def main():
     """Commande line interface"""
-
     parser = argparse.ArgumentParser(description='Extract parameters from an ULog file')
     parser.add_argument('filename', metavar='file.ulg', help='ULog input file')
 
-    parser.add_argument('-d', '--delimiter', dest='delimiter', action='store',
-                        help='Use delimiter in CSV (default is \',\')', default=',')
-
     parser.add_argument('-i', '--initial', dest='initial', action='store_true',
-                        help='Only extract initial parameters', default=False)
-
-    parser.add_argument('-o', '--octave', dest='octave', action='store_true',
-                        help='Use Octave format', default=False)
+                        help='Only extract initial parameters. (csv|octave|qgc)', default=False)
 
     parser.add_argument('-t', '--timestamps', dest='timestamps', action='store_true',
-                        help='Extract changed parameters with timestamps', default=False)
+                        help='Extract changed parameters with timestamps. (csv|qgc)', default=False)
 
-    parser.add_argument('-q', '--qgc_compatibility', dest='qgc_compatibility', action='store_true',
-                        help='Extract parameters in QGC compatible format', default=False)
+    parser.add_argument('-f', '--format', dest='format', action='store', type=str,
+                        help='csv|octave|qgc', default=False)
 
     parser.add_argument('output_filename', metavar='params.txt',
                         type=argparse.FileType('w'), nargs='?',
@@ -49,10 +42,10 @@ def main():
     ulog = ULog(ulog_file_name, message_filter, disable_str_exceptions)
 
     param_keys = sorted(ulog.initial_parameters.keys())
-    delimiter = args.delimiter
+    delimiter = ','
     output_file = args.output_filename
 
-    if not args.octave:
+    if not args.format == "octave":
         for param_key in param_keys:
             if args.timestamps:
                 output_file.write(param_key)
@@ -74,8 +67,7 @@ def main():
 
                 output_file.write('\n')
 
-            # QGC formatted parameter file
-            elif args.qgc_compatibility:
+            elif args.format == "qgc":
                 sys_id = 1
                 comp_id = 1
                 delimiter = '\t'


### PR DESCRIPTION
Added an option to `ulog_params` to output in the same format as QGC: 

**Vehicle-ID** -- **Component-ID** -- **Name** -- **Value** -- **Type** delimited with tabs.

This allows parameter files to be pulled from logs, and subsequently `diff`ed or uploaded.

@bkueng @jgoppert 