### PR TITLE
Added more options to the default color array.

### DIFF
--- a/pyulog/__init__.py
+++ b/pyulog/__init__.py
@@ -1,7 +1,5 @@
 """ Wrapper to include the main library modules """
 from .core import ULog
-from . import ulog2kml
-from . import ulog2csv
 from . import px4
 from . import _version
 

--- a/pyulog/__init__.py
+++ b/pyulog/__init__.py
@@ -1,5 +1,7 @@
 """ Wrapper to include the main library modules """
 from .core import ULog
+from . import ulog2kml
+from . import ulog2csv
 from . import px4
 from . import _version
 

--- a/pyulog/ulog2kml.py
+++ b/pyulog/ulog2kml.py
@@ -50,7 +50,9 @@ def _kml_default_colors(x):
     colors_arr = [simplekml.Color.red, simplekml.Color.green, simplekml.Color.blue,
                   simplekml.Color.violet, simplekml.Color.yellow, simplekml.Color.orange,
                   simplekml.Color.burlywood, simplekml.Color.azure, simplekml.Color.lightblue,
-                  simplekml.Color.lawngreen, simplekml.Color.indianred, simplekml.Color.hotpink]
+                  simplekml.Color.lawngreen, simplekml.Color.indianred, simplekml.Color.hotpink,
+                  simplekml.Color.bisque, simplekml.Color.cyan, simplekml.Color.darksalmon,
+                  simplekml.Color.deepskyblue, simplekml.Color.lime, simplekml.Color.orchid]
     return colors_arr[x]
 
 


### PR DESCRIPTION
After running VTOL flight tests, the ulog2kml command doesn't work due to the fact that a flight mode number is 15 exceeding the length of the default color array.

Added 6 more colors to the array to fix it and be able to run ulog2kml on any .ulg file

Also added ulog2kml and ulog2csv to __init__ for easier importing from other modules.