### PR TITLE
Fix CI issues

### DIFF
--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -605,10 +605,11 @@ class ULog(object):
                 current_file_position = self._file_handle.seek(current_file_position - len(chunk)\
                          + chunk_index + len(ULog.SYNC_BYTES), 0)
                 sync_seq_found = True
+                break
 
             elif last_n_bytes != -1:
                 # we read the whole last_n_bytes and did not find sync
-                pass
+                break
 
             # seek back 7 bytes to handle boundary condition and read next chunk
             current_file_position = self._file_handle.seek(-(len(ULog.SYNC_BYTES)-1), 1)

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -607,7 +607,7 @@ class ULog(object):
                 sync_seq_found = True
                 break
 
-            elif last_n_bytes != -1:
+            if last_n_bytes != -1:
                 # we read the whole last_n_bytes and did not find sync
                 break
 

--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -605,11 +605,10 @@ class ULog(object):
                 current_file_position = self._file_handle.seek(current_file_position - len(chunk)\
                          + chunk_index + len(ULog.SYNC_BYTES), 0)
                 sync_seq_found = True
-                break
 
             elif last_n_bytes != -1:
                 # we read the whole last_n_bytes and did not find sync
-                break
+                pass
 
             # seek back 7 bytes to handle boundary condition and read next chunk
             current_file_position = self._file_handle.seek(-(len(ULog.SYNC_BYTES)-1), 1)
@@ -784,4 +783,3 @@ class ULog(object):
             elif version[3] < 255: type_str = ' (RC)'
             return 'v{}.{}.{}{}'.format(version[0], version[1], version[2], type_str)
         return None
-

--- a/pyulog/extract_gps_dump.py
+++ b/pyulog/extract_gps_dump.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import argparse
 import os
+import sys
 
 from .core import ULog
 
@@ -55,7 +56,7 @@ def main():
 
     if len(data) == 0:
         print("File {0} does not contain gps_dump messages!".format(ulog_file_name))
-        exit(0)
+        sys.exit(0)
 
     gps_dump_data = data[0]
 
@@ -63,7 +64,7 @@ def main():
     field_names = [f.field_name for f in gps_dump_data.field_data]
     if not 'len' in field_names or not 'data[0]' in field_names:
         print('Error: gps_dump message has wrong format')
-        exit(-1)
+        sys.exit(-1)
 
     if len(ulog.dropouts) > 0:
         print("Warning: file contains {0} dropouts".format(len(ulog.dropouts)))


### PR DESCRIPTION
This PR solves two of the three problems with CI. Fixes an issue on version 3.4 and 3.5 where there was an unnecessary break in the `if` and `elif` functions and `exit()` instead of `sys.exit()`.


In version 2.7 there is still issue
```
E: 88,12: Assigning to function call which doesn't return (assignment-from-no-return)
```
from line:
```python
pitch = np.arcsin(2.0 * (q[0] * q[2] - q[3] * q[1]))
```
It can be related to pylint bug: https://github.com/PyCQA/pylint/issues/2694

But will python 2.7 be further supported? Official support of python 2.x ends on January 1.