### PR TITLE
add ulg to rosbag script

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,3 +211,25 @@ optional arguments:
   --camera-trigger CAMERA_TRIGGER
                         Camera trigger topic name (e.g. camera_capture)
 ```
+
+### Convert ULog to rosbag files (ulog2rosbag)
+
+> **Note** You need a ROS environment with `px4_msgs` built and sourced.
+
+Usage:
+```
+usage: ulog2rosbag [-h] [-m MESSAGES] file.ulg result.bag
+
+Convert ULog to rosbag
+
+positional arguments:
+  file.ulg              ULog input file
+  result.ulg            rosbag output file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -m MESSAGES, --messages MESSAGES
+                        Only consider given messages. Must be a comma-
+                        separated list of names, like
+                        'sensor_combined,vehicle_gps_position'
+```

--- a/pyulog/ulog2rosbag.py
+++ b/pyulog/ulog2rosbag.py
@@ -1,0 +1,96 @@
+#! /usr/bin/env python
+
+"""
+Convert a ULog file into rosbag file(s)
+"""
+
+from __future__ import print_function
+
+from collections import defaultdict
+import argparse
+import os
+import re
+import rospy
+import rosbag
+from px4_msgs import msg as px4_msgs
+
+from .core import ULog
+
+#pylint: disable=too-many-locals, invalid-name, consider-using-enumerate
+
+def main():
+    """Command line interface"""
+
+    parser = argparse.ArgumentParser(description='Convert ULog to rosbag')
+    parser.add_argument('filename', metavar='file.ulg', help='ULog input file')
+    parser.add_argument('bag', metavar='file.bag', help='rosbag output file')
+
+    parser.add_argument(
+        '-m', '--messages', dest='messages',
+        help=("Only consider given messages. Must be a comma-separated list of"
+              " names, like 'sensor_combined,vehicle_gps_position'"))
+
+    parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
+                        help='Ignore string parsing exceptions', default=False)
+
+    args = parser.parse_args()
+
+    convert_ulog2rosbag(args.filename, args.bag, args.messages, args.ignore)
+
+# from https://stackoverflow.com/questions/19053707/converting-snake-case-to-lower-camel-case-lowercamelcase
+def to_camel_case(snake_str):
+    components = snake_str.split("_")
+    return ''.join(x.title() for x in components)
+
+def convert_ulog2rosbag(ulog_file_name, rosbag_file_name, messages, disable_str_exceptions=False):
+    """
+    Coverts and ULog file to a CSV file.
+
+    :param ulog_file_name: The ULog filename to open and read
+    :param rosbag_file_name: The rosbag filename to open and write
+    :param messages: A list of message names
+
+    :return: No
+    """
+
+    array_pattern = re.compile(r"(.*?)\[(.*?)\]")
+    msg_filter = messages.split(',') if messages else None
+
+    ulog = ULog(ulog_file_name, msg_filter, disable_str_exceptions)
+    data = ulog.data_list
+
+    multiids = defaultdict(set)
+    for d in data:
+        multiids[d.name].add(d.multi_id)
+
+    with rosbag.Bag(rosbag_file_name, 'w') as bag:
+        items = []
+        for d in data:
+            if multiids[d.name] == {0}:
+                topic = "/px4/{}".format(d.name)
+            else:
+                topic = "/px4/{}_{}".format(d.name, d.multi_id)
+            msg_type = getattr(px4_msgs, to_camel_case(d.name))
+
+            for i in range(len(d.data['timestamp'])):
+                msg = msg_type()
+                for f in d.field_data:
+                    result = array_pattern.match(f.field_name)
+                    value = d.data[f.field_name][i]
+                    if result:
+                        field, array_index = result.groups()
+                        array_index = int(array_index)
+                        if isinstance(getattr(msg, field), bytes):
+                            attr = bytearray(getattr(msg, field))
+                            attr[array_index] = value
+                            setattr(msg, field, bytes(attr))
+                        else:
+                            getattr(msg, field)[array_index] = value
+                    else:
+                        setattr(msg, f.field_name, value)
+                ts = rospy.Time(nsecs=d.data['timestamp'][i]*1000)
+                items.append((topic, msg, ts))
+        items.sort(key=lambda x: x[2])
+        for topic, msg, ts in items:
+            bag.write(topic, msg, ts)
+

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             'ulog_params=pyulog.params:main',
             'ulog2csv=pyulog.ulog2csv:main',
             'ulog2kml=pyulog.ulog2kml:main',
+            'ulog2rosbag=pyulog.ulog2rosbag:main',
         ],
     },
     packages=find_packages(),


### PR DESCRIPTION
To streamline the logging capabilities, we considered converting the PX4 ulg files to rosbags to have a common way to display log files (for ROS1 / PX4). The conversion was easy as every uORB topic has a ROS1 msg type  defined in `px4_msgs`.

Example call:

```
ulog2rosbag ~/Documents/Logs/log_29_2021-9-3-16-43-10.ulg test.bag
```

