### PR TITLE
setup.py: Fix a broken link on the PyPI page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 This module allows you to parse ULog files, which are used within the PX4
 autopilot middleware.
 
-The file format is documented on https://dev.px4.io/advanced-ulog-file-format.html
+The file format is documented on https://docs.px4.io/master/en/dev_log/ulog_file_format.html
 
 """
 


### PR DESCRIPTION
The URL on https://pypi.org/project/pyulog/ is currently a broken link.