### PR TITLE
improve parsing in case of corrupted data

### DIFF
--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -467,7 +467,8 @@ class ULog(object):
 
         def initialize(self, data, header, subscriptions, ulog_object):
             msg_id, = ULog._unpack_ushort(data[:2])
-            if msg_id in subscriptions:
+            if msg_id in subscriptions \
+            and len(data)-2 == subscriptions[msg_id].dtype.itemsize:
                 subscription = subscriptions[msg_id]
                 # accumulate data to a buffer, will be parsed later
                 subscription.buffer += data[2:]


### PR DESCRIPTION
If data buffer size does not match the correct size (multiple of the size of the type):

- Do not crash to allow to read not corrupted data
- Try to read corrupted data anyway (some may be good ...). In some cases, it could be better to skip it.

This allows to read this corrupted flight log: https://drive.google.com/file/d/1m4qEjb3Zjsm5JFRXmTa7vvvA3rbOkRO_/view?usp=sharing