### PR TITLE
Update ulog2csv.py

### DIFF
--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -32,10 +32,10 @@ def main():
                         help='Output directory (default is same as input file)',
                         metavar='DIR')
     parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
-                        help='Ignore string parsing exceptions', default=False)                  
+                        help='Ignore string parsing exceptions', default=False)               
     parser.add_argument(
-        '-t', '--timestamp_start', dest='timestamp_start', type = int, 
-        help=("Only convert data after this timestamp(in seconds)"))
+        '-t', '--time_s', dest='time_s', type = int, 
+        help="Only convert data after this timestamp(in seconds)")
     
     args = parser.parse_args()
 
@@ -43,10 +43,10 @@ def main():
         print('Creating output directory {:}'.format(args.output))
         os.mkdir(args.output)
 
-    convert_ulog2csv(args.filename, args.messages, args.output, args.delimiter, args.timestamp_start, args.ignore)
+    convert_ulog2csv(args.filename, args.messages, args.output, args.delimiter, args.time_s, args.ignore)
 
 
-def convert_ulog2csv(ulog_file_name, messages, output, delimiter, timestamp_start, disable_str_exceptions=False):
+def convert_ulog2csv(ulog_file_name, messages, output, delimiter, time_s, disable_str_exceptions=False):
     """
     Coverts and ULog file to a CSV file.
 
@@ -54,7 +54,7 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter, timestamp_star
     :param messages: A list of message names
     :param output: Output file path
     :param delimiter: CSV delimiter
-    :param timestamp_start: Offset time for conversion(seconds)
+    :param time_s: Offset time for conversion(seconds)
 
     :return: None
     """
@@ -92,10 +92,10 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter, timestamp_star
             # write the header
             csvfile.write(delimiter.join(data_keys) + '\n')
             #get the index for row where timestamp exceeds or equals the required value
-            timestamp_start_index = np.where(d.data['timestamp'] >= timestamp_start * 1e6)[0][0] if timestamp_start else 0
+            time_index = np.where(d.data['timestamp'] >= time_s * 1e6)[0][0] if time_s else 0
             # write the data
             last_elem = len(data_keys)-1
-            for i in range(timestamp_start_index, len(d.data['timestamp'])):
+            for i in range(time_index, len(d.data['timestamp'])):
                 for k in range(len(data_keys)):
                     csvfile.write(str(d.data[data_keys[k]][i]))
                     if k != last_elem:

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -35,7 +35,7 @@ def main():
                         help='Ignore string parsing exceptions', default=False)               
     parser.add_argument(
         '-t', '--time_s', dest='time_s', type = int, 
-        help="Only convert data after this timestamp(in seconds)")
+        help="Only convert data after this timestamp (in seconds)")
     
     args = parser.parse_args()
 

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -32,7 +32,8 @@ def main():
                         help='Output directory (default is same as input file)',
                         metavar='DIR')
     parser.add_argument('-i', '--ignore', dest='ignore', action='store_true',
-                        help='Ignore string parsing exceptions', default=False)               
+                        help='Ignore string parsing exceptions', default=False)
+
     parser.add_argument(
         '-t', '--time_s', dest='time_s', type = int, 
         help="Only convert data after this timestamp (in seconds)")

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -102,4 +102,3 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter, timestamp_star
                         csvfile.write(delimiter)
                 csvfile.write('\n')
                 
-main()

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -85,7 +85,7 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter, time_s, disabl
             data_keys = [f.field_name for f in d.field_data]
             data_keys.remove('timestamp')
             data_keys.insert(0, 'timestamp')  # we want timestamp at first position
-            
+
             # we don't use np.savetxt, because we have multiple arrays with
             # potentially different data types. However the following is quite
             # slow...

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -37,7 +37,7 @@ def main():
     parser.add_argument(
         '-t', '--time_s', dest='time_s', type = int, 
         help="Only convert data after this timestamp (in seconds)")
-    
+
     args = parser.parse_args()
 
     if args.output and not os.path.isdir(args.output):
@@ -103,4 +103,4 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter, time_s, disabl
                     if k != last_elem:
                         csvfile.write(delimiter)
                 csvfile.write('\n')
-                
+

--- a/pyulog/ulog2csv.py
+++ b/pyulog/ulog2csv.py
@@ -83,8 +83,9 @@ def convert_ulog2csv(ulog_file_name, messages, output, delimiter, time_s, disabl
 
             # use same field order as in the log, except for the timestamp
             data_keys = [f.field_name for f in d.field_data]
-            data_keys.remove('timestamp')   
-            data_keys.insert(0, 'timestamp')  # we want timestamp at first positio
+            data_keys.remove('timestamp')
+            data_keys.insert(0, 'timestamp')  # we want timestamp at first position
+            
             # we don't use np.savetxt, because we have multiple arrays with
             # potentially different data types. However the following is quite
             # slow...

--- a/test/test_ulog2csv.py
+++ b/test/test_ulog2csv.py
@@ -46,7 +46,8 @@ class Test(unittest.TestCase):
         messages = []
         output=tmpdir
         delimiter=','
-        ulog2csv.convert_ulog2csv(ulog_file_name, messages, output, delimiter)
+        timestamp = 0
+        ulog2csv.convert_ulog2csv(ulog_file_name, messages, output, delimiter, timestamp)
 
     @data('sample', 'sample_appended', 'sample_appended_multiple')
     def test_pyulog_info_cli(self, test_case):

--- a/test/test_ulog2csv.py
+++ b/test/test_ulog2csv.py
@@ -46,8 +46,9 @@ class Test(unittest.TestCase):
         messages = []
         output=tmpdir
         delimiter=','
-        timestamp = 0
-        ulog2csv.convert_ulog2csv(ulog_file_name, messages, output, delimiter, timestamp)
+        time_s = 0
+        time_e = 1
+        ulog2csv.convert_ulog2csv(ulog_file_name, messages, output, delimiter, time_s, time_e)
 
     @data('sample', 'sample_appended', 'sample_appended_multiple')
     def test_pyulog_info_cli(self, test_case):

--- a/test/test_ulog2csv.py
+++ b/test/test_ulog2csv.py
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
         output=tmpdir
         delimiter=','
         time_s = 0
-        time_e = 1
+        time_e = 0
         ulog2csv.convert_ulog2csv(ulog_file_name, messages, output, delimiter, time_s, time_e)
 
     @data('sample', 'sample_appended', 'sample_appended_multiple')


### PR DESCRIPTION
I had a huge log file from a flight but the desired part of the log file only consisted of data towards the end of log file. So i added an additional optional parameter for the `ulog2csv` command to only convert data after the particular time. 

#### Usage:

`ulog2csv [-t time] file.ulg`
Convert the `file.ulg` to csv for which timestamp exceeds or equals `time` in seconds.  