### PR TITLE
fix a problem with saving ulogs [issue #81]

### DIFF
--- a/pyulog/core.py
+++ b/pyulog/core.py
@@ -354,6 +354,8 @@ class ULog(object):
         if value_type.startswith('char['):
             value_bytes = bytes(value, 'utf-8')
             data.extend(value_bytes)
+        elif value_type.startswith('uint8_t['):
+            data.extend(value)
         else:
             code = self._UNPACK_TYPES[value_type][0]
             data.extend(struct.pack('<' + code, value))


### PR DESCRIPTION
When `value_type` is uint8_t[, the `value` is already a bytearray, so `data` can be directly extended.

Resolves https://github.com/PX4/pyulog/issues/81 .