### PR TITLE
Add module to extract message values for use in scripting

### DIFF
--- a/pyulog/extract_message.py
+++ b/pyulog/extract_message.py
@@ -1,0 +1,53 @@
+"""
+Extract values from a ULog file message to use in scripting
+"""
+
+import numpy as np
+from .core import ULog
+
+def extract_message(ulog_file_name: str, message: str, time_s: "int | None" = None, time_e: "int | None" = None,
+                     disable_str_exceptions=False) -> list[dict]:
+    """
+    Extract values from a ULog file
+
+    :param ulog_file_name: (str) The ULog filename to open and read
+    :param message: (str) A ULog message to return values from
+    :param time_s: (int) Offset time for conversion in seconds
+    :param time_e: (int) Limit until time for conversion in seconds
+
+    :return: (list[dict]) A list of each record from the ULog as key-value pairs
+    """
+
+    if not type(message) == str:
+        raise AttributeError("Must provide a message to pull from ULog file")
+
+    msg_filter = message.split(',') if message else None
+
+    ulog = ULog(ulog_file_name, msg_filter, disable_str_exceptions)
+    data = ulog.data_list
+
+    if not data:
+        raise AttributeError("Provided message is not in the ULog file")
+
+    values = []
+    for record in data:
+        # use same field order as in the log, except for the timestamp
+        data_keys = [f.field_name for f in record.field_data]
+        data_keys.remove('timestamp')
+        data_keys.insert(0, 'timestamp')  # we want timestamp at first position
+
+        #get the index for row where timestamp exceeds or equals the required value
+        time_s_i = np.where(record.data['timestamp'] >= time_s * 1e6)[0][0] \
+                if time_s else 0
+        #get the index for row upto the timestamp of the required value
+        time_e_i = np.where(record.data['timestamp'] >= time_e * 1e6)[0][0] \
+                if time_e else len(record.data['timestamp'])
+
+        # write the data
+        for i in range(time_s_i, time_e_i):
+            row = {}
+            for k in range(len(data_keys)):
+                row[data_keys[k]] = record.data[data_keys[k]][i]
+            values.append(row)
+
+    return values

--- a/pyulog/extract_message.py
+++ b/pyulog/extract_message.py
@@ -5,8 +5,9 @@ Extract values from a ULog file message to use in scripting
 import numpy as np
 from .core import ULog
 
-def extract_message(ulog_file_name: str, message: str, time_s: "int | None" = None, time_e: "int | None" = None,
-                     disable_str_exceptions=False) -> list[dict]:
+def extract_message(ulog_file_name: str, message: str,
+                    time_s: "int | None" = None, time_e: "int | None" = None,
+                    disable_str_exceptions: bool = False) -> list[dict]:
     """
     Extract values from a ULog file
 
@@ -18,36 +19,35 @@ def extract_message(ulog_file_name: str, message: str, time_s: "int | None" = No
     :return: (list[dict]) A list of each record from the ULog as key-value pairs
     """
 
-    if not type(message) == str:
+    if not isinstance(message, str):
         raise AttributeError("Must provide a message to pull from ULog file")
 
-    msg_filter = message.split(',') if message else None
+    ulog = ULog(ulog_file_name, message, disable_str_exceptions)
 
-    ulog = ULog(ulog_file_name, msg_filter, disable_str_exceptions)
-    data = ulog.data_list
-
-    if not data:
-        raise AttributeError("Provided message is not in the ULog file")
+    try:
+        data = ulog.get_dataset(message)
+    except Exception as exc:
+        raise AttributeError("Provided message is not in the ULog file") from exc
 
     values = []
-    for record in data:
-        # use same field order as in the log, except for the timestamp
-        data_keys = [f.field_name for f in record.field_data]
-        data_keys.remove('timestamp')
-        data_keys.insert(0, 'timestamp')  # we want timestamp at first position
 
-        #get the index for row where timestamp exceeds or equals the required value
-        time_s_i = np.where(record.data['timestamp'] >= time_s * 1e6)[0][0] \
-                if time_s else 0
-        #get the index for row upto the timestamp of the required value
-        time_e_i = np.where(record.data['timestamp'] >= time_e * 1e6)[0][0] \
-                if time_e else len(record.data['timestamp'])
+    # use same field order as in the log, except for the timestamp
+    data_keys = [f.field_name for f in data.field_data]
+    data_keys.remove('timestamp')
+    data_keys.insert(0, 'timestamp')  # we want timestamp at first position
 
-        # write the data
-        for i in range(time_s_i, time_e_i):
-            row = {}
-            for k in range(len(data_keys)):
-                row[data_keys[k]] = record.data[data_keys[k]][i]
-            values.append(row)
+    #get the index for row where timestamp exceeds or equals the required value
+    time_s_i = np.where(data.data['timestamp'] >= time_s * 1e6)[0][0] \
+            if time_s else 0
+    #get the index for row upto the timestamp of the required value
+    time_e_i = np.where(data.data['timestamp'] >= time_e * 1e6)[0][0] \
+            if time_e else len(data.data['timestamp'])
+
+    # write the data
+    for i in range(time_s_i, time_e_i):
+        row = {}
+        for key in data_keys:
+            row[key] = data.data[key][i]
+        values.append(row)
 
     return values

--- a/test/test_extract_message.py
+++ b/test/test_extract_message.py
@@ -1,0 +1,37 @@
+'''
+Test extract_message module
+'''
+
+import os
+import inspect
+import unittest
+
+from ddt import ddt, data
+
+from pyulog.extract_message import extract_message
+
+TEST_PATH = os.path.dirname(os.path.abspath(
+    inspect.getfile(inspect.currentframe())))
+
+@ddt
+class TestExtractMessage(unittest.TestCase):
+    """
+    Test extract_message module.
+    """
+
+    @data('sample')
+    def test_extract_message(self, test_case):
+        """
+        Test that extract_message module runs without error.
+        """
+
+        ulog_file_name = os.path.join(TEST_PATH, test_case+'.ulg')
+        message = "actuator_controls_0"
+        time_s = None
+        time_e = None
+        extract_message(ulog_file_name,
+                        message,
+                        time_s,
+                        time_e)
+
+# vim: set et fenc=utf-8 ft=python ff=unix sts=4 sw=4 ts=4


### PR DESCRIPTION
This commit creates a module `extract_message` for extracting contents from a ULog message into a list to be used for scripting with ULog files. The module contains one function that takes in a ULog file, the desired message, and optionally a start and end time and returns a list of records from the ULog message as key-value pairs. I created this code by modifying the ulog2csv module.