### PR TITLE
Fix GPS msg_len overflow

### DIFF
--- a/pyulog/extract_gps_dump.py
+++ b/pyulog/extract_gps_dump.py
@@ -6,6 +6,7 @@ Extract the raw gps communication from an ULog file.
 import argparse
 import os
 import sys
+import numpy as np
 
 from .core import ULog
 
@@ -83,7 +84,7 @@ def main():
                 msg_len = msg_lens[i]
                 if instance == required_instance:
                     if msg_len & (1<<7):
-                        msg_len = msg_len & ~(1<<7)
+                        msg_len = msg_len & ~(np.uint8(1) << 7)
                         file_handle = to_dev_file
                     else:
                         file_handle = from_dev_file


### PR DESCRIPTION
## Problem

Whenever the condition `if msg_len & (1<<7)` is true, the extraction of the GPS dump fails with the following error:

```
Creating files log_7_2026-2-15-03-23-04_0_to_device.dat and log_7_2026-2-15-03-23-04_0_from_device.dat
Traceback (most recent call last):
  File "/home/alex/.local/bin/ulog_extract_gps_dump", line 8, in <module>
    sys.exit(main())
  File "/home/alex/.local/lib/python3.10/site-packages/pyulog/extract_gps_dump.py", line 86, in main
    msg_len = msg_len & ~(1<<7)
```

This is due to python trying to cast  `~(1<<7)` to a `np.uint8` as `msg_len` is a `np.uint8`. This will fail as python first does the shift and invert in its own signed int, causing a negative result, which can't be casted to an unsigned value.

## Solution
The shift and invert are done with a `np.uint8` so all math is done unsigned.